### PR TITLE
Git Ignore Fixture

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,5 @@ ENV/
 .DS_Store
 .vagrant
 .vscode
+/app_dir/*/migrations/*
+!/app_dir/*/migrations/__init__.py


### PR DESCRIPTION
### WHAT
added rules to ignore migrations on .gitignore
### WHY
To avoid commiting migrations.